### PR TITLE
add .strict method which only returns GA spec'd utm params

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,26 @@ $ component install segmentio/utm-params
 ### utm(querystring : string)
 
 ```js
-utm('?utm_source=google&utm_medium=medium&utm_term=keyword&utm_content=some%20content&utm_campaign=some%20campaign');
+utm('?utm_source=google&utm_medium=medium&utm_term=keyword&utm_content=some%20content&utm_campaign=some%20campaign&utm_test=other%20value');
+```
+
+```json
+{
+  "source": "google",
+  "medium": "medium",
+  "term": "keyword",
+  "content": "some content",
+  "name": "some campaign",
+  "test": "other value"
+}
+```
+
+###utm.strict(querystring : string)
+
+Will *only* return the 5 Google Analytics spec'd utm params 
+
+```js
+utm.strict('?utm_source=google&utm_medium=medium&utm_term=keyword&utm_content=some%20content&utm_campaign=some%20campaign&utm_test=other%20value');
 ```
 
 ```json

--- a/component.json
+++ b/component.json
@@ -8,7 +8,9 @@
     "index.js"
   ],
   "dependencies": {
-    "component/querystring": "*"
+    "component/querystring": "2.0.0",
+    "ndhoule/includes": "^1.0.0",
+    "ndhoule/foldl": "^1.0.3"
   },
   "development": {
     "component/assert": "*",

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@
  * Module dependencies.
  */
 
+var includes; try { includes = require('@ndhoule/includes'); } catch(e) { includes = require('ndhoule/includes'); }
+var foldl; try { foldl = require('@ndhoule/foldl'); } catch(e) { foldl = require('ndhoule/foldl'); }
 var parse = require('querystring').parse;
 
 /**
@@ -20,7 +22,7 @@ var has = Object.prototype.hasOwnProperty;
  * @api private
  */
 
-function utm(query){
+function utm(query) {
   // Remove leading ? if present
   if (query.charAt(0) === '?') {
     query = query.substring(1);
@@ -45,8 +47,32 @@ function utm(query){
   return results;
 }
 
+var allowedKeys = {
+  name: true,
+  term: true,
+  source: true,
+  medium: true,
+  content: true
+};
+
+/**
+ * Get strict utm params - from the given `querystring`
+ *
+ * @param {String} query
+ * @return {Object}
+ * @api private
+ */
+
+function strict(query) {
+  return foldl(function(acc, val, key) {
+    if (has.call(allowedKeys, key)) acc[key] = val;
+    return acc;
+  }, {}, utm(query));
+}
+
 /**
  * Exports.
  */
 
 module.exports = utm;
+module.exports.strict = strict;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,14 +13,16 @@ var utm = require('../index');
 
 describe('utm-params', function() {
   it('should parse utm params', function() {
-    var params = utm('?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name');
+    var params = utm('?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name&utm_test=test&utm_fake=fake');
 
     assert.deepEqual(params, {
       content: 'content',
       medium: 'medium',
       name: 'name',
       source: 'source',
-      term: 'term'
+      term: 'term',
+      fake: 'fake',
+      test: 'test'
     });
   });
 
@@ -42,3 +44,16 @@ describe('utm-params', function() {
     assert.deepEqual(params, { name: 'foo', source: 'baz' });
   });
 });
+
+describe('utm-params.strict', function() {
+    it('should omit unspecced utm params', function() {
+      var params = utm.strict('?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name&utm_test=test&utm_fake=fake');
+      assert.deepEqual(params, {
+        content: 'content',
+        medium: 'medium',
+        name: 'name',
+        source: 'source',
+        term: 'term'
+      });
+    });
+  });


### PR DESCRIPTION
`utm.strict` only returns utm params that are spec'd by GA. 

(these ones:)

![image](https://cloud.githubusercontent.com/assets/3130232/9371938/d3274898-468d-11e5-8c2e-019818e6bf0e.png)
